### PR TITLE
improve the rendering grab via web worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "vuer",
     "dist"
   ],
-  "main": "dist/vuer.cjs.js",
-  "module": "dist/vuer.es.js",
+  "main": "vuer/index.tsx",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -7,6 +7,7 @@
   "extends": "./tsconfig.json",
   "include": [
     "vuer/**/*.tsx",
+    "vuer/**/*.ts",
     ".eslintrc.cjs",
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,13 +9,14 @@
     "lib": [
       "ES2020",
       "DOM",
-      "DOM.Iterable"
+      "DOM.Iterable",
+      "webworker"
     ],
     "skipLibCheck": true,
     /* Bundler mode */
     "moduleResolution": "bundler",
     "noEmit": true,
-    "allowImportingTsExtensions": true,
+    "allowImportingTsExtensions": false,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/vuer/README.md
+++ b/vuer/README.md
@@ -208,7 +208,7 @@ type LumaShaderHooks = {
 
 Luma splats can be used with [React Three Fiber](https://docs.pmnd.rs/), a React renderer for Three.js. To do so, we need to extend R3F to include the `LumaSplatsThree` class. This is done by calling `extend` with the class and a name (in this case `LumaSplats` which will be used as the component name). If using TypeScript, we also need to declare the component type.
 
-**[DemoReactThreeFiber.tsx](./src/DemoReactThreeFiber.tsx)**
+**[DemoReactThreeFiber](./src/DemoReactThreeFiber)**
 ```typescript
 import { Object3DNode, extend } from '@react-three/fiber';
 import { LumaSplatsThree } from 'luma-web';

--- a/vuer/components/components.tsx
+++ b/vuer/components/components.tsx
@@ -38,24 +38,24 @@ import {
   TorusKnot,
   Tube,
   Wireframe,
-} from './three_components/primitives/primitives.tsx';
-import { Gripper, SkeletalGripper } from './three_components/components.tsx';
-import { Movable, Pivot } from './three_components/controls/movables.tsx';
-import { Camera } from './three_components/camera.tsx';
-import { BBox } from './three_components/primitives/bbox.tsx';
-import { CameraView } from './three_components/camera_view.tsx';
-import { AmbientLight, DirectionalLight, PointLight, SpotLight, } from './three_components/lighting.tsx';
-import { Frustum } from './three_components/frustum.tsx';
-import { Render, RenderLayer } from './nerf_components/view.tsx';
-import { Markdown } from './markdown/markdown.tsx';
-import { AutoScroll } from './chat/autoscroll.tsx';
-import { PointCloud } from './three_components/primitives/pointclound.tsx';
-import { TriMesh } from './three_components/primitives/trimesh.tsx';
-import { Gamepad } from './three_components/controls/gamepad.tsx';
-import { Hands } from './three_components/controls/hands.tsx';
-import { VuerProps } from '../interfaces.tsx';
-import { SceneBackground } from './three_components/scene_background.tsx';
-import { ImageBackground } from './three_components/image_background.tsx';
+} from './three_components/primitives/primitives';
+import { Gripper, SkeletalGripper } from './three_components/components';
+import { Movable, Pivot } from './three_components/controls/movables';
+import { Camera } from './three_components/camera';
+import { BBox } from './three_components/primitives/bbox';
+import { CameraView } from './three_components/camera_view/camera_view';
+import { AmbientLight, DirectionalLight, PointLight, SpotLight, } from './three_components/lighting';
+import { Frustum } from './three_components/frustum';
+import { Render, RenderLayer } from './nerf_components/view';
+import { Markdown } from './markdown/markdown';
+import { AutoScroll } from './chat/autoscroll';
+import { PointCloud } from './three_components/primitives/pointclound';
+import { TriMesh } from './three_components/primitives/trimesh';
+import { Gamepad } from './three_components/controls/gamepad';
+import { Hands } from './three_components/controls/hands';
+import { VuerProps } from '../interfaces';
+import { SceneBackground } from './three_components/scene_background';
+import { ImageBackground } from './three_components/image_background';
 import { CoordsMarker } from "./three_components/primitives/CoordsMarker";
 
 type VuerControlProps = VuerProps<{ value: never }>;

--- a/vuer/components/contexts/websocket.tsx
+++ b/vuer/components/contexts/websocket.tsx
@@ -6,10 +6,10 @@ import { button, useControls } from 'leva';
 import useStateRef from 'react-usestateref';
 import queryString from 'query-string';
 import { pack, unpack } from 'msgpackr';
-import { Store } from '../store.tsx';
+import { Store } from '../store';
 import { document } from '../../lib/browser-monads';
 
-import { ClientEvent, ServerEvent } from '../../interfaces.tsx';
+import { ClientEvent, ServerEvent } from '../../interfaces';
 
 export type msgFn = (event: ClientEvent) => void;
 export type SocketContextType = {

--- a/vuer/components/file_drop.tsx
+++ b/vuer/components/file_drop.tsx
@@ -5,7 +5,7 @@ import { useControls } from 'leva';
 import { pluginFile } from '../lib/leva-file-picker';
 import {
   Glb, Obj, Pcd, Ply, Urdf,
-} from './three_components/data_loaders.tsx';
+} from './three_components/data_loaders';
 
 export function FileDrop() {
   const [ buffer, setBuffer ] = useState(null);

--- a/vuer/components/index.tsx
+++ b/vuer/components/index.tsx
@@ -1,5 +1,5 @@
 import { ElementType } from 'react';
-import { comp_list } from './components.tsx';
+import { comp_list } from './components';
 import { Node } from '../index';
 
 type HydrateProps = {

--- a/vuer/components/markdown/markdown.tsx
+++ b/vuer/components/markdown/markdown.tsx
@@ -5,7 +5,7 @@ import {
 import rehypeRaw from 'rehype-raw';
 import { Remark } from 'react-remark';
 import { RemarkRehypeOptions } from 'react-markdown/lib';
-import { VuerProps } from '../../interfaces.tsx';
+import { VuerProps } from '../../interfaces';
 // @ts-ignore: not sure why this errors
 
 type MarkdownProps = VuerProps<{

--- a/vuer/components/nerf_components/view.tsx
+++ b/vuer/components/nerf_components/view.tsx
@@ -10,14 +10,14 @@ import {
 } from 'react';
 import { button, buttonGroup, useControls } from 'leva';
 import { ButtonInput, ButtonSettings } from 'leva/plugin';
-import { ImageBackground } from '../three_components/image_background.tsx';
-import { SocketContext, SocketContextType } from '../contexts/websocket.tsx';
-import { BBox } from '../three_components/primitives/bbox.tsx';
+import { ImageBackground } from '../three_components/image_background';
+import { SocketContext, SocketContextType } from '../contexts/websocket';
+import { BBox } from '../three_components/primitives/bbox';
 import {
   GroupSlave, rot2array, scale2array, v3array,
-} from '../three_components/group.tsx';
-import { ClientEvent, ServerEvent, VuerProps } from '../../interfaces.tsx';
-import { V3 } from '../three_components/number_types.tsx';
+} from '../three_components/group';
+import { ClientEvent, ServerEvent, VuerProps } from '../../interfaces';
+import { V3 } from '../three_components/number_types';
 
 export const RenderContext = createContext({});
 

--- a/vuer/components/store.tsx
+++ b/vuer/components/store.tsx
@@ -1,5 +1,5 @@
 import uuid4 from 'uuid4';
-import { EventType } from '../interfaces.tsx';
+import { EventType } from '../interfaces';
 
 export type ReducerType<E extends EventType> = (event: E) => E;
 export type HandlerType<E extends EventType> = (event: E) => void;

--- a/vuer/components/three_components/camera.tsx
+++ b/vuer/components/three_components/camera.tsx
@@ -22,8 +22,8 @@ import {
 import { useControls } from 'leva';
 import queryString from 'query-string';
 import { document } from '../../lib/browser-monads';
-import { SocketContext, SocketContextType } from '../contexts/websocket.tsx';
-import { VuerProps } from '../../interfaces.tsx'; // import {Line} from "./_primitives";
+import { SocketContext, SocketContextType } from '../contexts/websocket';
+import { VuerProps } from '../../interfaces'; // import {Line} from "./_primitives";
 // import {Line} from "./_primitives";
 
 const CAMERA_TYPES = {

--- a/vuer/components/three_components/camera_view/canvas_worker.ts
+++ b/vuer/components/three_components/camera_view/canvas_worker.ts
@@ -1,0 +1,38 @@
+// https://stackoverflow.com/questions/66649604/how-to-convert-a-rgba-array-to-a-jpeg-image-in-a-web-worker
+let canvas = null;
+
+function main() {
+  canvas = new OffscreenCanvas(100, 100);
+}
+
+self.onmessage = function ({ data: { rgba, width, height, dpr, targetDPR, mimeType = "image/jpeg", quality = 1 } }) {
+  const buffer = new Uint8Array(rgba);
+  // console.log('got message', buffer, width, height);
+
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  const imgData = ctx.getImageData(0, 0, width, height);
+  const data = imgData.data;  // the array of RGBA values
+
+  for (let i = 0; i < height; i++) {
+    const row_start = i * width * dpr * dpr * 4;
+    const target_row_start = i * width * 4
+    for (let j = 0; j < width; j++) {
+      const cell_start = row_start + j * dpr * 4;
+      const target_cell_start = target_row_start + j * 4;
+
+      data[target_cell_start] = buffer[cell_start];     // red
+      data[target_cell_start + 1] = buffer[cell_start + 1]; // green
+      data[target_cell_start + 2] = buffer[cell_start + 2]; // blue
+      data[target_cell_start + 3] = buffer[cell_start + 3]; // alpha
+    }
+  }
+
+  ctx.putImageData(imgData, 0, 0);
+  canvas.convertToBlob({ quality, type: mimeType }).then((blob) => blob.arrayBuffer()).then((array: ArrayBuffer) => {
+    self.postMessage({ jpg: array, width, height }, [ array ]);
+  })
+}
+
+main();

--- a/vuer/components/three_components/color.tsx
+++ b/vuer/components/three_components/color.tsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useMemo } from 'react';
 import { useControls } from 'leva';
 import queryString from 'query-string';
-import { SocketContext, SocketContextType } from '../contexts/websocket.tsx';
+import { SocketContext, SocketContextType } from '../contexts/websocket';
 
 interface BackgroundColorProps {
   levaPrefix?: string;

--- a/vuer/components/three_components/components.tsx
+++ b/vuer/components/three_components/components.tsx
@@ -5,7 +5,7 @@ import {
 } from 'three';
 import { URDFRobot } from 'urdf-loader';
 import { ThreeEvent } from '@react-three/fiber';
-import { VuerProps } from '../../interfaces.tsx';
+import { VuerProps } from '../../interfaces';
 
 type ObjProps = VuerProps<{
   data?: Points<BufferGeometry>;

--- a/vuer/components/three_components/controls/gamepad.tsx
+++ b/vuer/components/three_components/controls/gamepad.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import { useGamepads } from 'react-gamepads';
-import { SocketContext, SocketContextType } from '../../contexts/websocket.tsx';
-import { VuerProps } from '../../../interfaces.tsx';
+import { SocketContext, SocketContextType } from '../../contexts/websocket';
+import { VuerProps } from '../../../interfaces';
 
 export function Gamepad({ _key: key, children }: VuerProps) {
   const { sendMsg } = useContext(SocketContext) as SocketContextType;

--- a/vuer/components/three_components/controls/movables.tsx
+++ b/vuer/components/three_components/controls/movables.tsx
@@ -3,21 +3,20 @@ import {
   forwardRef,
   MutableRefObject,
   PropsWithChildren,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
   useRef,
   useState,
 } from 'react';
-import {
-  Euler, EulerOrder, Matrix4, Mesh, Object3D, Quaternion, Vector3,
-} from 'three';
+import { Euler, Matrix4, Mesh, Object3D, Quaternion, Vector3, } from 'three';
 import { invalidate, MeshProps, Vector3 as rVector3 } from '@react-three/fiber';
 import { PivotControls } from '@react-three/drei';
 import { useXR } from '@react-three/xr';
-import { SqueezeRayGrab } from './utils.tsx';
-import { VuerProps } from '../../../interfaces.tsx';
-import { SocketContext, SocketContextType } from '../../contexts/websocket.tsx';
+import { SqueezeRayGrab } from './utils';
+import { VuerProps } from '../../../interfaces';
+import { SocketContext, SocketContextType } from '../../contexts/websocket';
 
 export const HandleBox = forwardRef((
   {
@@ -25,13 +24,13 @@ export const HandleBox = forwardRef((
     children,
     ...rest
   }: MeshProps & PropsWithChildren<{
-    size: [number, number, number];
+    size: [ number, number, number ];
   }>,
   ref: ForwardedRef<Mesh>,
 ) => (
   <mesh ref={ref} {...rest}>
-    <boxGeometry args={size} />
-    <meshPhongMaterial color={0xfffff7} />
+    <boxGeometry args={size}/>
+    <meshPhongMaterial color={0xfffff7}/>
     {children}
   </mesh>
 ));
@@ -43,45 +42,54 @@ type Sim3Type = {
   scale: Vector3;
 };
 
+type MoveHandleInputType = {
+  matrix?: [ number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number ];
+  matrixWorld?: [ number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number ];
+  position?: [ number, number, number ];
+  rotation?: [ number, number, number, ]; // (EulerOrder | undefined) ];
+  quaternion?: [ number, number, number, number ];
+};
+
 type PivotProps = VuerProps<{
-  anchor?: [number, number, number];
-  offset?: [number, number, number];
+  anchor?: [ number, number, number ];
+  offset?: [ number, number, number ];
   scale?: number;
   lineWidth?: number;
-  matrix?: number[];
-  position?: [number, number, number];
-  rotation?: [number, number, number, (EulerOrder | undefined)];
-}>;
+  onMove?: (event: MoveHandleInputType) => void;
+  onMoveEnd?: (event: MoveHandleInputType) => void;
+} & MoveHandleInputType>;
 
 export function Pivot(
   {
     children,
     _key,
+    _ref,
     anchor,
     offset,
     scale = 0.4,
     lineWidth = 1.0,
     matrix,
     position = [ 0, 0, 0 ],
-    // @ts-ignore: type mismatch
     rotation = [ 0, 0, 0 ],
+    onMove, onMoveEnd,
     ...rest
   }: PivotProps,
 ) {
   const [ state, setState ] = useState({});
   const ref = useRef() as MutableRefObject<Object3D>;
+  const localRef = _ref || ref;
   const { sendMsg } = useContext(SocketContext) as SocketContextType;
 
   const cache = useMemo<Sim3Type>(() => ({
-    position: new Vector3(...position as [number, number, number]),
-    rotation: new Euler(...rotation as [number, number, number, (EulerOrder)]),
+    position: new Vector3(...position as [ number, number, number ]),
+    rotation: new Euler(...rotation as [ number, number, number ]),//, (EulerOrder) ]),
     quaternion: new Quaternion(),
     scale: new Vector3(),
   }), []);
 
   useEffect(() => {
-    if (!ref.current) return;
-    const pivot = ref.current;
+    if (!localRef.current) return;
+    const pivot = localRef.current;
     if (matrix) {
       pivot.matrix.fromArray(matrix);
       pivot.matrix.decompose(pivot.position, pivot.quaternion, pivot.scale);
@@ -92,7 +100,7 @@ export function Pivot(
       pivot.updateMatrix();
       invalidate();
     }
-  }, [ ref.current ]);
+  }, [ localRef.current ]);
 
   function onDrag(
     local: Matrix4,
@@ -106,18 +114,27 @@ export function Pivot(
   ): void {
     local.decompose(cache.position, cache.quaternion, cache.scale);
     cache.rotation.setFromQuaternion(cache.quaternion);
-    setState({
-      local: local.toArray(),
-      world: world.toArray(),
+
+    const newState = {
+      matrix: local.toArray(),
+      matrixWorld: world.toArray(),
       position: cache.position.toArray(),
       rotation: cache.rotation.toArray(),
       quaternion: cache.quaternion.toArray(),
+    } as MoveHandleInputType;
+
+    sendMsg({
+      etype: 'OBJECT_MOVE',
+      key: _key,
+      value: newState,
     });
+    onMove && onMove(newState);
+    setState(newState);
   }
 
   function onDragEnd() {
     sendMsg({
-      etype: 'OBJECT_MOVE',
+      etype: 'OBJECT_MOVE_END',
       key: _key,
       value: state,
     });
@@ -126,7 +143,7 @@ export function Pivot(
   return (
     <PivotControls
       // @ts-ignore: ref type mismatch
-      ref={ref}
+      ref={localRef}
       anchor={anchor}
       // annotations={annotations}
       offset={offset}
@@ -141,53 +158,10 @@ export function Pivot(
   );
 }
 
-// export function MovableGripper({_key, sendMsg, color = null, pinchWidth = 1, ...rest}) {
-//   const cloud_ref = useRef();
-//   const [pinchW, setPinchW] = useState(pinchWidth)
-//
-//   // make a ref for the sSkeletalGripper
-//   const gripper_ref = useRef()
-//   // use useMemo to create a skeleton gripper only once
-//   const gripperSkeleton = useMemo(() => <SkeletalGripper _ref={gripper_ref}/>, [])
-//
-//   const {position, rotation, handleOffset} = rest
-//
-//   const cache.position = useMemo(() => new Vector3(), [])
-//   const cache.quaternion = useMemo(() => new Quaternion(), [])
-//   const cache.rotation = useMemo(() => new Euler(), [])
-//   const cache.scale = useMemo(() => new Vector3(), [])
-//   const onSelect = () => {
-//     cloud_ref.current?.matrixWorld.decompose(cache.position, cache.quaternion, cache.scale)
-//     // convert cache.rotation quaternion to euler
-//     cache.rotation.setFrocache.quaternion(cache.quaternion)
-//     sendMsg({
-//       etype: 'SET_GRIPPER',
-//       key: _key,
-//       value: {
-//         rotation: cache.rotation.toArray().slice(0, 3),
-//         position: cache.position.toArray()
-//       }
-//     })
-//     // also set the skeletal gripper
-//     gripper_ref.current?.rotation.fromArray(cache.rotation.toArray())
-//     gripper_ref.current?.position.fromArray(cache.position.toArray())
-//   }
-//
-//   return (<>
-//         <SqueezeRayGrab onSelect={onSelect} bigChildren={
-//           <Gripper _ref={cloud_ref} color={color} pinchWidth={pinchW} {...rest}/>
-//         }>
-//           <HandleBox size={[0.1, 0.1, 0.1]} rotation={rotation} position={addThree(position, handleOffset)}/>
-//         </SqueezeRayGrab>
-//         {gripperSkeleton}
-//       </>
-//   )
-// }
-
 function addThree(
-  [ x1, y1, z1 ]: [number, number, number] = [ 0, 0, 0 ],
-  [ x2, y2, z2 ]: [number, number, number] = [ 0, 0, 0 ],
-): [number, number, number] {
+  [ x1, y1, z1 ]: [ number, number, number ] = [ 0, 0, 0 ],
+  [ x2, y2, z2 ]: [ number, number, number ] = [ 0, 0, 0 ],
+): [ number, number, number ] {
   return [
     x1 + x2,
     y1 + y2,
@@ -195,23 +169,33 @@ function addThree(
   ];
 }
 
+
 type PivotXRProps = VuerProps<{
-  offset: [number, number, number];
+  offset: [ number, number, number ];
   scale: number;
+  position: [ number, number, number ];
+  rotation: [ number, number, number ];
+  onMove?: (event: MoveHandleInputType) => void;
+  onMoveEnd?: (event: MoveHandleInputType) => void;
 }>;
 
 export function PivotXR(
   {
     _key,
+    _ref,
     offset,
     scale,
-    children = [],
     position,
     rotation,
+    children = [],
+    onMove,
+    onMoveEnd,
   }: PivotXRProps,
 ) {
   // const cloud_ref = useRef(children.length && children[0], children);
   const ref = useRef() as MutableRefObject<Mesh>;
+  const localRef = _ref || ref;
+
   const { sendMsg } = useContext(SocketContext) as SocketContextType;
 
   // make memo for position and rotation
@@ -222,27 +206,52 @@ export function PivotXR(
     scale: new Vector3(),
   }), []);
 
-  const onSqueezeEnd = () => {
-    const world = ref.current?.matrixWorld;
+  const onSqueezeEnd = useCallback(() => {
+    const local = localRef.current?.matrix;
+    const world = localRef.current?.matrixWorld;
     world.decompose(cache.position, cache.quaternion, cache.scale);
     // convert cache.rotation quaternion to euler
     cache.rotation.setFromQuaternion(cache.quaternion);
+    const state = {
+      // fixme: this is surely wrong.
+      matrix: local.toArray(),
+      matrixWorld: world.toArray(),
+      position: cache.position.toArray(),
+      rotation: cache.rotation.toArray(),
+      quaternion: cache.quaternion.toArray(),
+    } as MoveHandleInputType
+    onMoveEnd && onMoveEnd(state)
+    sendMsg({
+      etype: 'OBJECT_MOVE_END',
+      key: _key,
+      value: state,
+    });
+  }, []);
+
+  const onMoveHandle = useCallback(({ local, world }) => {
+    world.decompose(cache.position, cache.quaternion, cache.scale);
+    // convert cache.rotation quaternion to euler
+    cache.rotation.setFromQuaternion(cache.quaternion);
+    const state = {
+      matrix: local.toArray(),
+      matrixWorld: world.toArray(),
+      position: cache.position.toArray(),
+      rotation: cache.rotation.toArray(),
+      quaternion: cache.quaternion.toArray(),
+    } as MoveHandleInputType
+    onMove && onMove(state)
     sendMsg({
       etype: 'OBJECT_MOVE',
       key: _key,
-      value: {
-        world: world.toArray(),
-        position: cache.position.toArray(),
-        rotation: cache.rotation.toArray(),
-        quaternion: cache.quaternion.toArray(),
-      },
+      value: state,
     });
-  };
+  }, []);
+
 
   return (
-    <SqueezeRayGrab onSqueezeEnd={onSqueezeEnd} bigChildren={children}>
+    <SqueezeRayGrab onSqueezeEnd={onSqueezeEnd} onMove={onMoveHandle} bigChildren={children}>
       <HandleBox
-        ref={ref}
+        ref={localRef}
         size={[ scale, scale, scale ]}
         rotation={rotation}
         position={addThree(position, offset) as rVector3}
@@ -252,24 +261,25 @@ export function PivotXR(
 }
 
 type MovableType = VuerProps<{
-  anchor?: [number, number, number];
-  offset?: [number, number, number];
+  anchor?: [ number, number, number ];
+  offset?: [ number, number, number ];
   annotations?: string[];
   scale?: number;
   lineWidth?: number;
-  handleOffset?: [number, number, number];
+  handleOffset?: [ number, number, number ];
   hide?: boolean;
-}>;
+} & PivotXRProps & PivotProps>;
 
 export function Movable(
   {
-    children,
     _key,
+    _ref,
+    children,
     anchor,
     offset,
     annotations,
     scale = 0.4,
-    lineWidth = 0.5,
+    lineWidth = 2,
     handleOffset = [ 0, 0, 0 ],
     hide,
     ...props
@@ -282,6 +292,7 @@ export function Movable(
     return (
       <PivotXR
         _key={_key}
+        _ref={_ref}
         scale={scale * 0.1}
         offset={handleOffset}
         {...props}
@@ -289,9 +300,11 @@ export function Movable(
         {children}
       </PivotXR>
     );
-  } return (
+  }
+  return (
     <Pivot
       _key={_key}
+      _ref={_ref}
       anchor={anchor}
       offset={offset}
       annotations={annotations}

--- a/vuer/components/three_components/controls/pointer.tsx
+++ b/vuer/components/three_components/controls/pointer.tsx
@@ -9,7 +9,7 @@ import {
 } from '@react-three/fiber';
 import { Sphere as ThreeSphere } from '@react-three/drei';
 import { useControls } from 'leva';
-import { SocketContext, SocketContextType } from '../../contexts/websocket.tsx';
+import { SocketContext, SocketContextType } from '../../contexts/websocket';
 
 function getPosition(
   camera: Camera,

--- a/vuer/components/three_components/controls/utils.tsx
+++ b/vuer/components/three_components/controls/utils.tsx
@@ -1,15 +1,14 @@
-import {
-  ForwardedRef, forwardRef, MutableRefObject, ReactNode, useMemo, useRef,
-} from 'react';
+import { ForwardedRef, forwardRef, MutableRefObject, ReactNode, useMemo, useRef, } from 'react';
 import { Interactive, XRController, XRInteractionEvent } from '@react-three/xr';
 import { useFrame } from '@react-three/fiber';
 
 import { Group, Matrix4 } from 'three';
-import { VuerProps } from '../../../interfaces.tsx';
+import { VuerProps } from '../../../interfaces';
 
 type SqueezeRayGrabProps = VuerProps<{
   onSqueezeStart?: (e?: XRInteractionEvent) => void;
   onSqueezeEnd?: (e?: XRInteractionEvent) => void;
+  onMove?: (e?: { world: Matrix4; local: Matrix4 }) => void;
   onSelect?: (e?: XRInteractionEvent) => void;
   bigChildren?: ReactNode | ReactNode[];
   [key: string]: unknown;
@@ -18,6 +17,7 @@ type SqueezeRayGrabProps = VuerProps<{
 export const SqueezeRayGrab = forwardRef((
   {
     onSqueezeStart,
+    onMove,
     onSqueezeEnd,
     onSelect,
     children,
@@ -35,6 +35,7 @@ export const SqueezeRayGrab = forwardRef((
   useFrame(() => {
     const controller = grabbingController.current;
     if (!groupRef.current || !controller) return null;
+
     const group = groupRef.current;
 
     group.applyMatrix4(previousTransform);
@@ -42,6 +43,9 @@ export const SqueezeRayGrab = forwardRef((
     group.updateMatrixWorld();
 
     previousTransform.copy(controller.matrixWorld).invert();
+
+    onMove?.({ world: controller.matrixWorld, local: controller.matrix });
+
   });
 
   return (
@@ -61,10 +65,10 @@ export const SqueezeRayGrab = forwardRef((
           }
           onSqueezeEnd?.(e);
         }}
-        {...rest}
         onSelect={(e) => {
           onSelect?.(e);
         }}
+        {...rest}
       >
         {children}
       </Interactive>

--- a/vuer/components/three_components/data_loaders.tsx
+++ b/vuer/components/three_components/data_loaders.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren, useContext, useEffect, useMemo, useState } from 'rea
 import { GLTF, GLTFLoader, OBJLoader, PCDLoader, PLYLoader, STLLoader, } from 'three-stdlib';
 import URDFLoader, { URDFRobot } from 'urdf-loader';
 import { BufferGeometry, LoadingManager, Mesh, MeshStandardMaterial, Object3D, Points } from 'three'; // todo: pass reference
-import { GltfView, ObjView, PcdView, PlyView, UrdfView, } from './components.tsx';
+import { GltfView, ObjView, PcdView, PlyView, UrdfView, } from './components';
 import { AppContext } from "../../index";
 
 // todo: pass reference

--- a/vuer/components/three_components/download.tsx
+++ b/vuer/components/three_components/download.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useContext } from 'react';
 import { useThree } from '@react-three/fiber';
 import { button, useControls } from 'leva';
-import { SocketContext, SocketContextType } from '../contexts/websocket.tsx';
-import { VuerProps } from '../../interfaces.tsx';
+import { SocketContext, SocketContextType } from '../contexts/websocket';
+import { VuerProps } from '../../interfaces';
 
 export function Download({ _key: key }: VuerProps) {
   const { sendMsg }: SocketContextType = useContext(SocketContext);

--- a/vuer/components/three_components/frustum.tsx
+++ b/vuer/components/three_components/frustum.tsx
@@ -5,7 +5,7 @@ import {
   ColorRepresentation, Euler, Group, Matrix4, Object3D, Quaternion, Vector3,
 } from 'three';
 import { Line, Sphere } from '@react-three/drei';
-import { VuerProps } from '../../interfaces.tsx';
+import { VuerProps } from '../../interfaces';
 
 function equals(aArr: number[], bArr: number[]) {
   for (let i = 0; i < aArr.length; i++) {

--- a/vuer/components/three_components/grid.tsx
+++ b/vuer/components/three_components/grid.tsx
@@ -10,7 +10,12 @@ interface GridQueries {
   grid?: string;
 }
 
-export function Grid({ far = null, levaPrefix = 'Scene.' }): JSX.Element {
+interface GridProps {
+  far?: number;
+  levaPrefix?: string;
+}
+
+export function Grid({ far = null, levaPrefix = 'Scene.' }: GridProps): JSX.Element {
   const q = useMemo<GridQueries>(
     () => queryString.parse(document.location.search),
     [],

--- a/vuer/components/three_components/group.tsx
+++ b/vuer/components/three_components/group.tsx
@@ -4,12 +4,12 @@ import {
 import { useControls } from 'leva';
 import queryString, { ParsedQuery } from 'query-string';
 import { Euler, Vector3 } from '@react-three/fiber';
-import { SocketContext, SocketContextType } from '../contexts/websocket.tsx';
+import { SocketContext, SocketContextType } from '../contexts/websocket';
 import { document } from '../../lib/browser-monads';
-import { SceneStoreType, useSceneStore } from '../../store.tsx';
+import { SceneStoreType, useSceneStore } from '../../store';
 
-import { ClientEvent } from '../../interfaces.tsx';
-import { Sim3, SO3, V3 } from './number_types.tsx';
+import { ClientEvent } from '../../interfaces';
+import { Sim3, SO3, V3 } from './number_types';
 
 export function deg2rad(rotation: SO3): SO3 {
   return {

--- a/vuer/components/three_components/index.tsx
+++ b/vuer/components/three_components/index.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from 'react';
-import ThreeScene from './scene.tsx';
+import ThreeScene from './scene';
 
 type SceneProps = PropsWithChildren<{
   _key: string,

--- a/vuer/components/three_components/lighting.tsx
+++ b/vuer/components/three_components/lighting.tsx
@@ -12,7 +12,7 @@ import {
   SpotLightHelper,
 } from 'three';
 import { PointLightProps } from '@react-three/fiber';
-import { VuerProps } from '../../interfaces.tsx';
+import { VuerProps } from '../../interfaces';
 
 type LightProps<TL> = VuerProps<{
   color: Color | undefined;

--- a/vuer/components/three_components/primitives/height_map_materials.tsx
+++ b/vuer/components/three_components/primitives/height_map_materials.tsx
@@ -7,7 +7,7 @@ import { useControls } from 'leva';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error
 import { TextureImageData } from 'three/src/textures/types';
-import { height2normal } from './normal_map_utils.tsx';
+import { height2normal } from './normal_map_utils';
 
 // export function SimpleMaterial({_key, displacementMap, normalMap, ...rest}) {
 //     const dM = useLoader(TextureLoader, displacementMap);

--- a/vuer/components/three_components/primitives/pointclound.tsx
+++ b/vuer/components/three_components/primitives/pointclound.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren, Ref, useMemo } from 'react';
 import { Euler, Points, Vector3 } from 'three';
-import { half2float } from './half2float.tsx';
+import { half2float } from './half2float';
 
 type PointCloudProps = PropsWithChildren<{
   _key?: string;

--- a/vuer/components/three_components/primitives/primitives.tsx
+++ b/vuer/components/three_components/primitives/primitives.tsx
@@ -5,7 +5,7 @@ import { Mesh, TextureLoader } from 'three';
 import { useLoader } from '@react-three/fiber';
 import { Outlines } from '@react-three/drei';
 import { useControls } from 'leva';
-import { HeightMaterial } from './height_map_materials.tsx';
+import { HeightMaterial } from './height_map_materials';
 
 type PrimitiveProps = {
   _ref?: Ref<Mesh>;

--- a/vuer/components/three_components/primitives/trimesh.tsx
+++ b/vuer/components/three_components/primitives/trimesh.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { MeshProps } from '@react-three/fiber';
-import { half2float } from './half2float.tsx';
+import { half2float } from './half2float';
 
 enum Side { front, back, double }
 

--- a/vuer/components/three_components/scene.tsx
+++ b/vuer/components/three_components/scene.tsx
@@ -8,16 +8,16 @@ import { BufferGeometry, Mesh, Object3D, Vector3 } from 'three';
 import { acceleratedRaycast, computeBoundsTree, disposeBoundsTree } from 'three-mesh-bvh';
 import { Perf } from 'r3f-perf';
 import queryString, { ParsedQuery } from 'query-string';
-import { CameraLike, OrbitCamera } from './camera.tsx';
-import { Download } from './download.tsx';
+import { CameraLike, OrbitCamera } from './camera';
+import { Download } from './download';
 // import {FileDrop} from "../_file_drop";
-import { Grid } from './grid.tsx';
-import { PointerControl } from './controls/pointer.tsx';
-import { SceneGroup } from './group.tsx';
-import { SocketContext, SocketContextType } from '../contexts/websocket.tsx';
-import { BackgroundColor } from './color.tsx';
+import { Grid } from './grid';
+import { PointerControl } from './controls/pointer';
+import { SceneGroup } from './group';
+import { SocketContext, SocketContextType } from '../contexts/websocket';
+import { BackgroundColor } from './color';
 import { document } from '../../lib/browser-monads';
-import { ClientEvent } from '../../interfaces.tsx';
+import { ClientEvent } from '../../interfaces';
 
 // question: what does this do? - Ge
 Mesh.prototype.raycast = acceleratedRaycast;
@@ -43,6 +43,7 @@ type ThreeProps = PropsWithChildren<{
   backgroundChildren?: unknown | unknown[];
   rawChildren?: unknown | unknown[];
   htmlChildren?: unknown | unknown[];
+  grid?: boolean;
 }>;
 
 export default function ThreeScene(
@@ -57,11 +58,12 @@ export default function ThreeScene(
     rawChildren,
     htmlChildren,
     up = null,
+    grid = false,
   }: ThreeProps,
 ) {
   const ref = useRef<HTMLCanvasElement>();
   const canvasRef = _canvasRef || ref;
-  const { sendMsg, uplink } = useContext(SocketContext) as SocketContextType;
+  const { sendMsg, uplink, downlink } = useContext(SocketContext) as SocketContextType;
   const queries = useMemo<ParsedQuery>(() => queryString.parse(document.location.search), []);
 
   useEffect(() => {
@@ -86,6 +88,11 @@ export default function ThreeScene(
     [ sendMsg, uplink ],
   );
 
+  // useEffect(() => {
+  //   downlink.subscribe('GRAB_REDNER', (event: ClientEvent) => {
+  //   }
+  // }, [])
+
   const divStyle = useMemo(
     () => ({
       overflow: 'hidden',
@@ -106,7 +113,7 @@ export default function ThreeScene(
         <Canvas
           ref={canvasRef}
           shadows
-          // preserve buffer needed for download
+          // preserve buffer needed for download and grab image data
           gl={{ antialias: true, preserveDrawingBuffer: true }}
           frameloop="demand"
           // why set it to 1: https://stackoverflow.com/a/32936969/1560241
@@ -123,7 +130,7 @@ export default function ThreeScene(
               parent={canvasRef}
               parentKey={key}
             />
-            <Grid/>
+            {grid ? <Grid/> : null}
             {backgroundChildren}
             <Suspense>
               <SceneGroup>{children}</SceneGroup>

--- a/vuer/index.tsx
+++ b/vuer/index.tsx
@@ -5,14 +5,14 @@ import useFetch from 'use-http';
 import yaml from 'js-yaml';
 import useStateRef from 'react-usestateref';
 import { document } from './lib/browser-monads';
-import ThreeScene from './components/three_components/scene.tsx';
+import ThreeScene from './components/three_components/scene';
 import { Hydrate } from './components';
-import { list2menu } from './components/three_components/leva_helper.tsx';
-import { addNode, findByKey, removeByKey } from './util.tsx';
-import { WebSocketProvider } from './components/contexts/websocket.tsx';
-import { parseArray } from './components/three_components/utils.tsx';
+import { list2menu } from './components/three_components/leva_helper';
+import { addNode, findByKey, removeByKey } from './util';
+import { WebSocketProvider } from './components/contexts/websocket';
+import { parseArray } from './components/three_components/utils';
 import { Buffer } from "buffer";
-import { ServerEvent } from './interfaces.tsx';
+import { ServerEvent } from './interfaces';
 import { pack, unpack } from "msgpackr";
 
 // The dataloader component hides the list of children from the outer scope.
@@ -136,7 +136,8 @@ export default function VuerRoot({ style, children: _, ..._props }: VuerRootProp
       "Share": button(() => {
         const sceneStr = pack(scene);
         if (sceneStr.length > 10_000) {
-          return showError("The scene likely contains a large amount of data. To share, please replace geometry data with an URI. Length is" + sceneStr.length + " bytes.")
+          return showError(`The scene likely contains a large amount of data. To share, please replace 
+          geometry data with an URI. Length is ${sceneStr.length} bytes.`)
         }
         const chars = String.fromCharCode.apply(null, sceneStr)
         const scene64b = btoa(chars);
@@ -220,7 +221,6 @@ export default function VuerRoot({ style, children: _, ..._props }: VuerRootProp
     backgroundChildren: sceneBackgroundChildren,
     ..._scene
   } = scene;
-  console.log(_props, scene);
 
   // very problematic
   const rest = {


### PR DESCRIPTION
Performance is greatly improved. 
- now use frames-per-second to throttle the rendering. 
- uses a web worker to convert the image into jpeg. This compresses 1.4MB down to 700kB for 320 x 240 images. (also dpr == 1)

<img width="1012" alt="Screenshot 2023-12-17 at 12 31 17 AM" src="https://github.com/vuer-ai/vuer-ts/assets/630490/f787449e-559c-444b-ad66-82e15359db34">
