### PR TITLE
Ge camera view sync grab 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vuer-ai/vuer",
   "author": "Ge Yang",
-  "version": "0.0.18-patch-2",
+  "version": "0.0.18-patch-3",
   "private": false,
   "files": [
     "vuer",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vuer-ai/vuer",
   "author": "Ge Yang",
-  "version": "0.0.18-patch-1",
+  "version": "0.0.18-patch-2",
   "private": false,
   "files": [
     "vuer",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vuer-ai/vuer",
   "author": "Ge Yang",
-  "version": "0.0.18-patch-3",
+  "version": "0.0.18-patch-4",
   "private": false,
   "files": [
     "vuer",

--- a/vuer/index.tsx
+++ b/vuer/index.tsx
@@ -10,7 +10,6 @@ import { Hydrate } from './html_components';
 import { list2menu } from './three_components/leva_helper';
 import { addNode, findByKey, removeByKey, upsert } from './util';
 import { WebSocketProvider } from './html_components/contexts/websocket';
-import { parseArray } from './three_components/utils';
 import { ServerEvent } from './interfaces';
 import { pack, unpack } from "msgpackr";
 import { Buffer } from "buffer";

--- a/vuer/three_components/camera_view/GrabRender.tsx
+++ b/vuer/three_components/camera_view/GrabRender.tsx
@@ -2,6 +2,7 @@ import { useContext, useEffect, useMemo } from "react";
 import { useThree } from "@react-three/fiber";
 import { ServerRPC } from "../../interfaces";
 import { SocketContext, SocketContextType } from "../../html_components/contexts/websocket";
+import { CameraLike } from "../camera";
 
 export type GrabRenderEvent = ServerRPC & {
   // this is the UUID of the request.
@@ -9,16 +10,18 @@ export type GrabRenderEvent = ServerRPC & {
   data: {
     // width: number;
     // height: number;
-    downsample: number;
+    // not being used in the camera_view component.
+    downsample?: number;
     quality?: number;
   }
 }
 
 type GrabeRenderProps = {
   _key: string;
+  camera?: CameraLike;
 }
 
-const GrabRender = ({ _key = "DEFAULT" }: GrabeRenderProps) => {
+const GrabRender = ({ _key = "DEFAULT", camera = null }: GrabeRenderProps) => {
   const dpr = window.devicePixelRatio || 1;
   const { sendMsg, downlink, uplink } = useContext(SocketContext) as SocketContextType;
   const { gl } = useThree();

--- a/vuer/three_components/camera_view/GrabRender.tsx
+++ b/vuer/three_components/camera_view/GrabRender.tsx
@@ -18,10 +18,10 @@ export type GrabRenderEvent = ServerRPC & {
 
 type GrabeRenderProps = {
   _key: string;
-  camera?: CameraLike;
+  // camera?: CameraLike;
 }
 
-const GrabRender = ({ _key = "DEFAULT", camera = null }: GrabeRenderProps) => {
+const GrabRender = ({ _key = "DEFAULT" }: GrabeRenderProps) => {
   const dpr = window.devicePixelRatio || 1;
   const { sendMsg, downlink, uplink } = useContext(SocketContext) as SocketContextType;
   const { gl } = useThree();

--- a/vuer/three_components/camera_view/PerspectiveCamera.tsx
+++ b/vuer/three_components/camera_view/PerspectiveCamera.tsx
@@ -1,0 +1,80 @@
+import { PerspectiveCamera as PerspectiveCameraImpl } from 'three'
+import { useFrame, useThree } from '@react-three/fiber'
+import mergeRefs from 'react-merge-refs'
+import { useFBO } from "@react-three/drei";
+import { forwardRef, useLayoutEffect, useRef } from 'react';
+import { ForwardRefComponent } from "@react-three/drei/helpers/ts-utils";
+
+const isFunction = (node: any): node is Function => typeof node === 'function'
+
+type Props = Omit<JSX.IntrinsicElements['perspectiveCamera'], 'children'> & {
+  /** Registers the camera as the system default, fiber will start rendering with it */
+  makeDefault?: boolean
+  /** Making it manual will stop responsiveness and you have to calculate aspect ratio yourself. */
+  manual?: boolean
+  /** The contents will either follow the camera, or be hidden when filming if you pass a function */
+  children?: React.ReactNode | ((texture: THREE.Texture) => React.ReactNode)
+  /** Number of frames to render, Infinity */
+  frames?: number
+  /** Resolution of the FBO, 256 */
+  resolution?: number
+  /** Optional environment map for functional use */
+  envMap?: THREE.Texture
+}
+
+export const PerspectiveCamera: ForwardRefComponent<Props, PerspectiveCameraImpl> = /* @__PURE__ */ forwardRef(
+  ({ envMap, resolution = 256, frames = Infinity, makeDefault, children, ...props }: Props, ref) => {
+    const set = useThree(({ set }) => set)
+    const camera = useThree(({ camera }) => camera)
+    // const size = useThree(({ size }) => size)
+    const cameraRef = useRef<PerspectiveCameraImpl>(null!)
+    const groupRef = useRef<THREE.Group>(null!)
+    const fbo = useFBO(resolution)
+
+    // React.useLayoutEffect(() => {
+    //   if (!props.manual) {
+    //     cameraRef.current.aspect = size.width / size.height
+    //   }
+    // }, [size, props])
+    //
+    // React.useLayoutEffect(() => {
+    //   cameraRef.current.updateProjectionMatrix()
+    // })
+
+    let count = 0
+    let oldEnvMap: THREE.Color | THREE.Texture | null = null
+    const functional = isFunction(children)
+    useFrame((state) => {
+      if (functional && (frames === Infinity || count < frames)) {
+        groupRef.current.visible = false
+        state.gl.setRenderTarget(fbo)
+        oldEnvMap = state.scene.background
+        if (envMap) state.scene.background = envMap
+        state.gl.render(state.scene, cameraRef.current)
+        state.scene.background = oldEnvMap
+        state.gl.setRenderTarget(null)
+        groupRef.current.visible = true
+        count++
+      }
+    })
+
+    useLayoutEffect(() => {
+      if (makeDefault) {
+        const oldCam = camera
+        set(() => ({ camera: cameraRef.current! }))
+        return () => set(() => ({ camera: oldCam }))
+      }
+      // The camera should not be part of the dependency list because this components camera is a stable reference
+      // that must exchange the default, and clean up after itself on unmount.
+    }, [ cameraRef, makeDefault, set ])
+
+    return (
+      <>
+        <perspectiveCamera ref={mergeRefs([ cameraRef, ref ])} {...props}>
+          {!functional && children}
+        </perspectiveCamera>
+        <group ref={groupRef}>{functional && children(fbo.texture)}</group>
+      </>
+    )
+  }
+)

--- a/vuer/three_components/primitives/primitives.tsx
+++ b/vuer/three_components/primitives/primitives.tsx
@@ -1,5 +1,5 @@
-import { Ref, Suspense, useEffect, useLayoutEffect, useRef, useState, } from 'react';
-import { Mesh, TextureLoader, UnsignedInt248Type } from 'three';
+import { Ref, Suspense, useEffect, useState, } from 'react';
+import { Mesh, TextureLoader } from 'three';
 import { useLoader } from '@react-three/fiber';
 import { Outlines } from '@react-three/drei';
 import { useControls } from 'leva';

--- a/vuer/three_components/scene.tsx
+++ b/vuer/three_components/scene.tsx
@@ -80,7 +80,7 @@ export function Scene({
 
   const ref = useRef<HTMLCanvasElement>();
   const canvasRef = _canvasRef || ref;
-  const { sendMsg, uplink, downlink } = useContext(SocketContext) as SocketContextType;
+  const { sendMsg, uplink } = useContext(SocketContext) as SocketContextType;
   const queries = useMemo<ParsedQuery>(() => queryString.parse(document.location.search), []);
 
   useEffect(() => {

--- a/vuer/three_components/scene_background.tsx
+++ b/vuer/three_components/scene_background.tsx
@@ -9,7 +9,7 @@ interface BackgroundImageParams {
 }
 
 export function SceneBackground({ src }: BackgroundImageParams) {
-  const { scene, gl } = useThree();
+  const { scene } = useThree();
   const loader: TextureLoader = useMemo(() => new TextureLoader(), []);
   const [ rgbTexture, setRGB ] = useState<Texture | undefined>();
 


### PR DESCRIPTION
Added synchronous grab_render API for the virtual camera. 

The example is here: https://docs.vuer.ai/en/latest/tutorials/camera/grab_render_virtual_camera.html

<img width="1800" alt="Screenshot 2024-01-16 at 6 05 00 PM" src="https://github.com/vuer-ai/vuer-ts/assets/630490/c63e1fb1-6737-4270-9aaf-843239f58457">
